### PR TITLE
Updated correct path to bio image

### DIFF
--- a/proposals/a-HAPI-alternative-to-REST_jheising.md
+++ b/proposals/a-HAPI-alternative-to-REST_jheising.md
@@ -15,7 +15,7 @@ Join us for what is likely to be a lively and heated discussion on the current a
 
 ##Speaker Bio
 
-![](https://raw.github.com/cascadiajs/2013.cascadiajs.com/master/images/jimheising.png)
+![](https://raw.github.com/cascadiajs/2014.cascadiajs.com/master/images/jimheising.png)
 
 According to legend (aka Mom and Dad) Jim Heising began his software development career on an Apple ][+ before he could read, when he crafted the wildly successful program:
 

--- a/proposals/node.js-for-fun-profit-and-whiskey_jheising.md
+++ b/proposals/node.js-for-fun-profit-and-whiskey_jheising.md
@@ -13,7 +13,7 @@ If logistics permit, we might even provide a small sample tasting of alcohol pro
 
 ##Speaker Bio
 
-![](https://raw.github.com/cascadiajs/2013.cascadiajs.com/master/images/jimheising.png)
+![](https://raw.github.com/cascadiajs/2014.cascadiajs.com/master/images/jimheising.png)
 
 According to legend (aka Mom and Dad) Jim Heising began his software development career on an Apple ][+ before he could read, when he crafted the wildly successful program:
 


### PR DESCRIPTION
Sample template had a link to 2013 project and got carried over to 2014. Updated to 2014 to fix broken images.
