### PR TITLE
Fix a Broken Image Reference

### DIFF
--- a/proposals/monkeys-in-the-machine_ericmann.md
+++ b/proposals/monkeys-in-the-machine_ericmann.md
@@ -16,7 +16,7 @@ Attendees will walk away with a better understanding of asynchronous behavior an
 
 ##Speaker Bio
 
-![](https://raw.github.com/cascadiajs/2013.cascadiajs.com/master/images/ericmann.png)
+![](https://raw.github.com/cascadiajs/2014.cascadiajs.com/master/images/ericmann.png)
 
 Eric Mann is a seasoned web developer with experience in languages from JavaScript to Ruby to C#.  He has been building websites of all shapes and sizes for the better part of a decade and continues to experiment with new technologies and techniques.
 

--- a/proposals/unit-testing-minutes-now-will-save-hours-later_ericmann.md
+++ b/proposals/unit-testing-minutes-now-will-save-hours-later_ericmann.md
@@ -15,7 +15,7 @@ Drafting unit tests for JavaScript isn’t glamorous, but it will save you time 
 
 ##Speaker Bio
 
-![](https://raw.github.com/cascadiajs/2013.cascadiajs.com/master/images/ericmann.png)
+![](https://raw.github.com/cascadiajs/2014.cascadiajs.com/master/images/ericmann.png)
 
 Eric Mann is a seasoned web developer with experience in languages from JavaScript to Ruby to C#.  He has been building websites of all shapes and sizes for the better part of a decade and continues to experiment with new technologies and techniques.
 


### PR DESCRIPTION
I mistakenly copied an older proposal template that referenced the 2013
site for speaker images. I wasn't aware of the mistake until after my pull
requests were merged in, but was hoping to fix the broken image links
currently referenced.
